### PR TITLE
fault counters in right eye, fix indentation-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/launch.json
 .vscode/ipch
 platformio.ini
+output.map


### PR DESCRIPTION
* 2021-01-13 DE: - recover from mistakenly editing master instead of a branch:
 *                - track time spent in MQTT routines, although it's embedded on other numbers (turns out its tiny)
 *                - include time for CPU usage calculation in loop's CPU bucket 
 *                - remove unused code planned for loop() optimization
 *                - simplify call to mqttClient.publish() in publishMQTT() to avoid cpomplier errors. The workaround for the
 *                   compiler error was causing "1" to be printed in serial monitor MQTT commands and parameters
 *                   case insensitive, so you can use  camel case, lower case, upper case, or random case
 *                - add display of left and right DRV fault counters to bottom right corner of right eye. Seeing numbers for
 *                  right eye, even in simple hand held operation.